### PR TITLE
add queue options to config schema

### DIFF
--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -4,6 +4,17 @@ import mimetypes from "./mimetypes.mjs";
 export const config = {
   type: "object",
   properties: {
+    queue: {
+      type: "object",
+      properties: {
+        options: {
+          type: "object",
+          properties: {
+            concurrent: { type: "number" },
+          },
+        },
+      },
+    },
     endpoints: {
       type: "object",
       propertyNames: {

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -13,7 +13,7 @@ export const config = {
           type: "object",
           required: ["concurrent"],
           properties: {
-            concurrent: { type: "number" },
+            concurrent: { type: "integer" },
           },
         },
       },

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -3,12 +3,15 @@ import mimetypes from "./mimetypes.mjs";
 
 export const config = {
   type: "object",
+  required: ["queue"],
   properties: {
     queue: {
       type: "object",
+      required: ["options"],
       properties: {
         options: {
           type: "object",
+          required: ["concurrent"],
           properties: {
             concurrent: { type: "number" },
           },

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -61,6 +61,7 @@ test("compile schema", (t) => {
   ajv.compile(manifestation);
   ajv.compile(manifestations);
   ajv.compile(config);
+  ajv.compile(crawlPath);
   t.pass();
 });
 

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -209,6 +209,27 @@ test("should be a valid config", (t) => {
   t.true(valid);
 });
 
+test("should be an invalid config", (t) => {
+  const check = ajv.compile(config);
+  const example = {
+    queue: {
+      options: {
+        // concurrent options is required but missing here
+      },
+    },
+    endpoints: {
+      "https://eth-mainnet.alchemyapi.io": {
+        timeout: 3000,
+        requestsPerUnit: 100,
+        unit: "second",
+      },
+    },
+  };
+
+  const valid = check(example);
+  t.false(valid);
+});
+
 test("should be a valid crawlPath", (t) => {
   const check = ajv.compile(crawlPath);
   const example = [

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -191,6 +191,11 @@ test("validate value", (t) => {
 test("should be a valid config", (t) => {
   const check = ajv.compile(config);
   const example = {
+    queue: {
+      options: {
+        concurrent: 10,
+      },
+    },
     endpoints: {
       "https://eth-mainnet.alchemyapi.io": {
         timeout: 3000,


### PR DESCRIPTION
This allows us to use the config schema to validate workerData. In issue neume-network/extraction-worker#39 we want extraction worker to validate `workerData.endpoints` but we don't have a schema for only endpoints. In this PR I have chosen the alternative approach of adding queue options to config. Now we can validate config schema in extraction worker.

TODO: 
- [x] Create a PR in extraction-worker