### PR TITLE
add an ipfs worker message

### DIFF
--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -125,6 +125,47 @@ export const jsonrpc = {
   ],
 };
 
+export const ipfs = {
+  type: "object",
+  properties: {
+    type: {
+      type: "string",
+      enum: ["ipfs"],
+    },
+    commissioner: {
+      type: "string",
+    },
+    version: {
+      type: "string",
+    },
+    options: {
+      type: "object",
+      properties: {
+        timeout: {
+          $comment: "temporal unit is milliseconds",
+          type: "integer",
+        },
+        url: { type: "string" },
+        gateway: {
+          type: "string",
+          pattern: "^.+ipfs/$",
+          $comment: "http gateway for ipfs should end with ipfs/",
+        },
+      },
+      required: ["url", "gateway"],
+    },
+    results: {
+      type: "object",
+      nullable: true,
+    },
+    error: {
+      type: "string",
+      nullable: true,
+    },
+  },
+  required: ["type", "commissioner", "version", "error", "results", "options"],
+};
+
 export const exit = {
   type: "object",
   required: ["type", "version"],
@@ -140,7 +181,7 @@ export const exit = {
 };
 
 export const workerMessage = {
-  oneOf: [https, graphql, jsonrpc, exit],
+  oneOf: [https, graphql, jsonrpc, ipfs, exit],
 };
 
 export const config = {

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -145,14 +145,14 @@ export const ipfs = {
           $comment: "temporal unit is milliseconds",
           type: "integer",
         },
-        url: { type: "string" },
+        uri: { type: "string" },
         gateway: {
           type: "string",
           pattern: "^.+ipfs/$",
           $comment: "http gateway for ipfs should end with ipfs/",
         },
       },
-      required: ["url", "gateway"],
+      required: ["uri", "gateway"],
     },
     results: {
       type: "object",

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -16,6 +16,7 @@ import {
   manifestations,
   config,
   crawlPath,
+  ipfs,
 } from "../src/schema.mjs";
 
 const ajv = new Ajv();
@@ -330,4 +331,41 @@ test("if crawl path validator throws if transformer.args[0] isn't a string", (t)
   t.false(valid);
   t.true(check.errors[0].instancePath.includes("transformer/args/0"));
   t.is(check.errors[0].message, "must be string");
+});
+
+test("should be a valid ipfs message", async (t) => {
+  const check = ajv.compile(ipfs);
+  const message = {
+    options: {
+      url: "ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
+      gateway: `https://ipfs.io/ipfs/`,
+    },
+    version: "1.0.0",
+    type: "ipfs",
+    commissioner: "test",
+    results: null,
+    error: null,
+  };
+
+  const valid = check(message);
+  t.true(valid);
+});
+
+test("ipfs message url should end with ipfs/", async (t) => {
+  const check = ajv.compile(ipfs);
+  const message = {
+    options: {
+      url: "ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
+      gateway: `https://ipfs.io/`,
+    },
+    version: "1.0.0",
+    type: "ipfs",
+    commissioner: "test",
+    results: null,
+    error: null,
+  };
+
+  const valid = check(message);
+  t.false(valid);
+  t.true(check.errors[0].instancePath.includes("/options/gateway"));
 });

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -337,7 +337,7 @@ test("should be a valid ipfs message", async (t) => {
   const check = ajv.compile(ipfs);
   const message = {
     options: {
-      url: "ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
+      uri: "ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
       gateway: `https://ipfs.io/ipfs/`,
     },
     version: "1.0.0",
@@ -355,7 +355,7 @@ test("ipfs message url should end with ipfs/", async (t) => {
   const check = ajv.compile(ipfs);
   const message = {
     options: {
-      url: "ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
+      uri: "ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu",
       gateway: `https://ipfs.io/`,
     },
     version: "1.0.0",


### PR DESCRIPTION
Fixes #35. The message expects a native IPFS URL e.g. `ipfs://Qmeb...`. The actual CID checking will be done in extraction worker using the multiformats library.