### PR TITLE
Make `results` and `error` non-mandatory

### DIFF
--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -30,14 +30,12 @@ export const https = {
     },
     results: {
       type: "object",
-      nullable: true
     },
     error: {
       type: "string",
-      nullable: true
-    }
+    },
   },
-  required: ["type", "commissioner", "version", "error", "results", "options"]
+  required: ["type", "commissioner", "version", "options"],
 };
 
 export const graphql = {
@@ -64,14 +62,12 @@ export const graphql = {
     },
     results: {
       type: "object",
-      nullable: true
     },
     error: {
       type: "string",
-      nullable: true
-    }
+    },
   },
-  required: ["type", "commissioner", "version", "options", "results", "error"]
+  required: ["type", "commissioner", "version", "options"],
 };
 
 export const jsonrpc = {
@@ -106,20 +102,16 @@ export const jsonrpc = {
     },
     results: {
       type: "object",
-      nullable: true
     },
     error: {
       type: "string",
-      nullable: true
     }
   },
-  // TODO: Require `error`
   required: [
     "type",
     "commissioner",
     "method",
     "params",
-    "results",
     "version",
     "options"
   ]
@@ -157,14 +149,12 @@ export const ipfs = {
     },
     results: {
       type: "object",
-      nullable: true
     },
     error: {
       type: "string",
-      nullable: true
     }
   },
-  required: ["type", "commissioner", "version", "error", "results", "options"]
+  required: ["type", "commissioner", "version", "options"]
 };
 
 export const exit = {

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -343,8 +343,6 @@ test("should be a valid ipfs message", async (t) => {
     version: "1.0.0",
     type: "ipfs",
     commissioner: "test",
-    results: null,
-    error: null,
   };
 
   const valid = check(message);
@@ -361,8 +359,6 @@ test("ipfs gateway is a https url", async (t) => {
     version: "1.0.0",
     type: "ipfs",
     commissioner: "test",
-    results: null,
-    error: null,
   };
 
   const valid = check(message);
@@ -380,8 +376,6 @@ test("ipfs message url should end with ipfs/", async (t) => {
     version: "1.0.0",
     type: "ipfs",
     commissioner: "test",
-    results: null,
-    error: null,
   };
 
   const valid = check(message);


### PR DESCRIPTION
- Fixes #42

@il3ven do you think this will lead to many problems when we have to integrate this change into lifecycle?