### PR TITLE
let github automatically figure out ref in actions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,13 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
-          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
-          persist-credentials: false
-
+        uses: actions/checkout@v3
       - name: Prettify code
         uses: creyD/prettier_action@v4.2
         with:


### PR DESCRIPTION
Fixes the issue of not being able to run this workflow from forks.