### PR TITLE
modify schema for `track`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,18 @@
 
 export type WorkerMessage = Https | Graphql | Jsonrpc | Ipfs | Arweave | Exit;
 export type Version = string;
+export type ERC721Metadata = {
+  name: string;
+  description: string;
+  image: string;
+  [k: string]: unknown;
+} & ERC721Metadata1;
+export type ERC721Metadata1 = {
+  name: string;
+  description: string;
+  image: string;
+  [k: string]: unknown;
+} | null;
 /**
  * @minItems 1
  */
@@ -32,6 +44,8 @@ export type CrawlPath = [
     [k: string]: unknown;
   }[][]
 ];
+export type Owners = Owner[];
+export type Tokens = Token[];
 
 export interface Https {
   type: "https";
@@ -167,31 +181,37 @@ export interface Config {
   };
   [k: string]: unknown;
 }
-export interface ERC721Metadata {
-  name: string;
-  description: string;
-  image: string;
-  [k: string]: unknown;
-}
 export interface ERC721 {
   version: string;
-  createdAt: number;
-  transaction: {
-    from: string;
-    to: string;
-    blockNumber: number;
-    transactionHash: string;
-    [k: string]: unknown;
-  };
+  tokens: Token[];
   address: string;
-  tokenId: string;
-  tokenURI: string;
-  metadata: {
+  uri?: string | null;
+  metadata?: {
     name: string;
     description: string;
     image: string;
     [k: string]: unknown;
-  };
+  } | null;
+  [k: string]: unknown;
+}
+export interface Token {
+  id: string;
+  uri?: string | null;
+  metadata?: {
+    name: string;
+    description: string;
+    image: string;
+    [k: string]: unknown;
+  } | null;
+  owners: Owner[];
+  [k: string]: unknown;
+}
+export interface Owner {
+  from: string;
+  to: string;
+  blockNumber: number;
+  transactionHash: string;
+  alias?: string | null;
   [k: string]: unknown;
 }
 export interface Artist {
@@ -215,6 +235,7 @@ export interface Manifestation {
 export interface Track {
   version: string;
   title: string;
+  uid: string;
   duration?: string;
   artist: {
     version: string;
@@ -230,33 +251,17 @@ export interface Track {
   };
   erc721: {
     version: string;
-    createdAt: number;
-    transaction: {
-      from: string;
-      to: string;
-      blockNumber: number;
-      transactionHash: string;
-      [k: string]: unknown;
-    };
+    tokens: Token[];
     address: string;
-    tokenId: string;
-    tokenURI: string;
-    metadata: {
+    uri?: string | null;
+    metadata?: {
       name: string;
       description: string;
       image: string;
       [k: string]: unknown;
-    };
+    } | null;
     [k: string]: unknown;
   };
   manifestations: Manifestation[];
   [k: string]: unknown;
 }
-export interface Transaction {
-  from: string;
-  to: string;
-  blockNumber: number;
-  transactionHash: string;
-  [k: string]: unknown;
-}
-

--- a/schema.json
+++ b/schema.json
@@ -8,6 +8,10 @@
     "title": {
       "type": "string"
     },
+    "uid": {
+      "$comment": "Unique ID to identify the track",
+      "type": "string"
+    },
     "duration": {
       "type": "string",
       "format": "duration"
@@ -23,14 +27,10 @@
           "type": "string"
         },
         "address": {
-          "type": "string",
-          "pattern": "0x[a-fA-F0-9]{40}"
+          "type": "string"
         }
       },
-      "required": [
-        "version",
-        "name"
-      ]
+      "required": ["version", "name"]
     },
     "platform": {
       "type": "object",
@@ -47,11 +47,7 @@
           "format": "uri"
         }
       },
-      "required": [
-        "version",
-        "name",
-        "uri"
-      ]
+      "required": ["version", "name", "uri"]
     },
     "erc721": {
       "type": "object",
@@ -60,52 +56,79 @@
           "type": "string",
           "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
         },
-        "createdAt": {
-          "$comment": "Referring to Ethereum block numbers",
-          "type": "integer",
-          "minimum": 0
-        },
-        "transaction": {
-          "type": "object",
-          "$comment": "History of EIP 721 transfer events",
-          "properties": {
-            "from": {
-              "type": "string",
-              "pattern": "0x[a-fA-F0-9]{40}"
+        "tokens": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "uri": {
+                "type": ["string", "null"]
+              },
+              "metadata": {
+                "type": ["object", "null"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "image": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": ["name", "description", "image"]
+              },
+              "owners": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "$comment": "Owner of the track",
+                  "properties": {
+                    "from": {
+                      "type": "string",
+                      "pattern": "0x[a-fA-F0-9]{40}"
+                    },
+                    "to": {
+                      "type": "string",
+                      "pattern": "0x[a-fA-F0-9]{40}"
+                    },
+                    "blockNumber": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "transactionHash": {
+                      "type": "string",
+                      "pattern": "0x[a-fA-F0-9]{64}"
+                    },
+                    "alias": {
+                      "type": ["string", "null"],
+                      "$comment": "Alias for address. For example, ENS."
+                    }
+                  },
+                  "required": ["from", "to", "blockNumber", "transactionHash"]
+                }
+              }
             },
-            "to": {
-              "type": "string",
-              "pattern": "0x[a-fA-F0-9]{40}"
-            },
-            "blockNumber": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "transactionHash": {
-              "type": "string",
-              "pattern": "0x[a-fA-F0-9]{64}"
-            }
-          },
-          "required": [
-            "from",
-            "to",
-            "blockNumber",
-            "transactionHash"
-          ]
+            "required": ["id", "owners"]
+          }
         },
         "address": {
+          "$comment": "The address where the NFTs are minted",
           "type": "string",
           "pattern": "0x[a-fA-F0-9]{40}"
         },
-        "tokenId": {
-          "type": "string"
-        },
-        "tokenURI": {
-          "type": "string",
-          "format": "uri"
+        "uri": {
+          "$comment": "tokenURI where the metadata was found. Similar to metadata, if tokenURI is common for all tokens we can use this field.",
+          "type": ["string", "null"]
         },
         "metadata": {
-          "type": "object",
+          "$comment": "If the metadata is same for all the tokens we can use this field",
+          "type": ["object", "null"],
           "properties": {
             "name": {
               "type": "string"
@@ -118,22 +141,10 @@
               "format": "uri"
             }
           },
-          "required": [
-            "name",
-            "description",
-            "image"
-          ]
+          "required": ["name", "description", "image"]
         }
       },
-      "required": [
-        "version",
-        "createdAt",
-        "address",
-        "tokenId",
-        "tokenURI",
-        "metadata",
-        "transaction"
-      ]
+      "required": ["version", "tokens", "address"]
     },
     "manifestations": {
       "type": "array",
@@ -153,11 +164,7 @@
             "pattern": "audio|image|video|audio/1d-interleaved-parityfec|audio/32kadpcm|audio/3gpp|audio/3gpp2|audio/aac|audio/ac3|audio/adpcm|audio/amr|audio/amr-wb|audio/amr-wb+|audio/aptx|audio/asc|audio/atrac-advanced-lossless|audio/atrac-x|audio/atrac3|audio/basic|audio/bv16|audio/bv32|audio/clearmode|audio/cn|audio/dat12|audio/dls|audio/dsr-es201108|audio/dsr-es202050|audio/dsr-es202211|audio/dsr-es202212|audio/dv|audio/dvi4|audio/eac3|audio/encaprtp|audio/evrc|audio/evrc-qcp|audio/evrc0|audio/evrc1|audio/evrcb|audio/evrcb0|audio/evrcb1|audio/evrcnw|audio/evrcnw0|audio/evrcnw1|audio/evrcwb|audio/evrcwb0|audio/evrcwb1|audio/evs|audio/flexfec|audio/fwdred|audio/g711-0|audio/g719|audio/g722|audio/g7221|audio/g723|audio/g726-16|audio/g726-24|audio/g726-32|audio/g726-40|audio/g728|audio/g729|audio/g7291|audio/g729d|audio/g729e|audio/gsm|audio/gsm-efr|audio/gsm-hr-08|audio/ilbc|audio/ip-mr_v2.5|audio/isac|audio/l16|audio/l20|audio/l24|audio/l8|audio/lpc|audio/melp|audio/melp1200|audio/melp2400|audio/melp600|audio/mhas|audio/midi|audio/mobile-xmf|audio/mp3|audio/mp4|audio/mp4a-latm|audio/mpa|audio/mpa-robust|audio/mpeg|audio/mpeg4-generic|audio/musepack|audio/ogg|audio/opus|audio/parityfec|audio/pcma|audio/pcma-wb|audio/pcmu|audio/pcmu-wb|audio/prs.sid|audio/qcelp|audio/raptorfec|audio/red|audio/rtp-enc-aescm128|audio/rtp-midi|audio/rtploopback|audio/rtx|audio/s3m|audio/scip|audio/silk|audio/smv|audio/smv-qcp|audio/smv0|audio/sofa|audio/sp-midi|audio/speex|audio/t140c|audio/t38|audio/telephone-event|audio/tetra_acelp|audio/tetra_acelp_bb|audio/tone|audio/tsvcis|audio/uemclip|audio/ulpfec|audio/usac|audio/vdvi|audio/vmr-wb|audio/vnd.3gpp.iufp|audio/vnd.4sb|audio/vnd.audiokoz|audio/vnd.celp|audio/vnd.cisco.nse|audio/vnd.cmles.radio-events|audio/vnd.cns.anp1|audio/vnd.cns.inf1|audio/vnd.dece.audio|audio/vnd.digital-winds|audio/vnd.dlna.adts|audio/vnd.dolby.heaac.1|audio/vnd.dolby.heaac.2|audio/vnd.dolby.mlp|audio/vnd.dolby.mps|audio/vnd.dolby.pl2|audio/vnd.dolby.pl2x|audio/vnd.dolby.pl2z|audio/vnd.dolby.pulse.1|audio/vnd.dra|audio/vnd.dts|audio/vnd.dts.hd|audio/vnd.dts.uhd|audio/vnd.dvb.file|audio/vnd.everad.plj|audio/vnd.hns.audio|audio/vnd.lucent.voice|audio/vnd.ms-playready.media.pya|audio/vnd.nokia.mobile-xmf|audio/vnd.nortel.vbk|audio/vnd.nuera.ecelp4800|audio/vnd.nuera.ecelp7470|audio/vnd.nuera.ecelp9600|audio/vnd.octel.sbc|audio/vnd.presonus.multitrack|audio/vnd.qcelp|audio/vnd.rhetorex.32kadpcm|audio/vnd.rip|audio/vnd.rn-realaudio|audio/vnd.sealedmedia.softseal.mpeg|audio/vnd.vmx.cvsd|audio/vnd.wave|audio/vorbis|audio/vorbis-config|audio/wav|audio/wave|audio/webm|audio/x-aac|audio/x-aiff|audio/x-caf|audio/x-flac|audio/x-m4a|audio/x-matroska|audio/x-mpegurl|audio/x-ms-wax|audio/x-ms-wma|audio/x-pn-realaudio|audio/x-pn-realaudio-plugin|audio/x-realaudio|audio/x-tta|audio/x-wav|audio/xm|font/collection|font/otf|font/sfnt|font/ttf|font/woff|font/woff2|image/aces|image/apng|image/avci|image/avcs|image/avif|image/bmp|image/cgm|image/dicom-rle|image/emf|image/fits|image/g3fax|image/gif|image/heic|image/heic-sequence|image/heif|image/heif-sequence|image/hej2k|image/hsj2|image/ief|image/jls|image/jp2|image/jpeg|image/jph|image/jphc|image/jpm|image/jpx|image/jxr|image/jxra|image/jxrs|image/jxs|image/jxsc|image/jxsi|image/jxss|image/ktx|image/ktx2|image/naplps|image/pjpeg|image/png|image/prs.btif|image/prs.pti|image/pwg-raster|image/sgi|image/svg+xml|image/t38|image/tiff|image/tiff-fx|image/vnd.adobe.photoshop|image/vnd.airzip.accelerator.azv|image/vnd.cns.inf2|image/vnd.dece.graphic|image/vnd.djvu|image/vnd.dvb.subtitle|image/vnd.dwg|image/vnd.dxf|image/vnd.fastbidsheet|image/vnd.fpx|image/vnd.fst|image/vnd.fujixerox.edmics-mmr|image/vnd.fujixerox.edmics-rlc|image/vnd.globalgraphics.pgb|image/vnd.microsoft.icon|image/vnd.mix|image/vnd.mozilla.apng|image/vnd.ms-dds|image/vnd.ms-modi|image/vnd.ms-photo|image/vnd.net-fpx|image/vnd.pco.b16|image/vnd.radiance|image/vnd.sealed.png|image/vnd.sealedmedia.softseal.gif|image/vnd.sealedmedia.softseal.jpg|image/vnd.svf|image/vnd.tencent.tap|image/vnd.valve.source.texture|image/vnd.wap.wbmp|image/vnd.xiff|image/vnd.zbrush.pcx|image/webp|image/wmf|image/x-3ds|image/x-cmu-raster|image/x-cmx|image/x-freehand|image/x-icon|image/x-jng|image/x-mrsid-image|image/x-ms-bmp|image/x-pcx|image/x-pict|image/x-portable-anymap|image/x-portable-bitmap|image/x-portable-graymap|image/x-portable-pixmap|image/x-rgb|image/x-tga|image/x-xbitmap|image/x-xcf|image/x-xpixmap|image/x-xwindowdump|text/1d-interleaved-parityfec|text/cache-manifest|text/calendar|text/calender|text/cmd|text/coffeescript|text/cql|text/cql-expression|text/cql-identifier|text/css|text/csv|text/csv-schema|text/directory|text/dns|text/ecmascript|text/encaprtp|text/enriched|text/fhirpath|text/flexfec|text/fwdred|text/gff3|text/grammar-ref-list|text/html|text/jade|text/javascript|text/jcr-cnd|text/jsx|text/less|text/markdown|text/mathml|text/mdx|text/mizar|text/n3|text/parameters|text/parityfec|text/plain|text/provenance-notation|text/prs.fallenstein.rst|text/prs.lines.tag|text/prs.prop.logic|text/raptorfec|text/red|text/rfc822-headers|text/richtext|text/rtf|text/rtp-enc-aescm128|text/rtploopback|text/rtx|text/sgml|text/shaclc|text/shex|text/slim|text/spdx|text/strings|text/stylus|text/t140|text/tab-separated-values|text/troff|text/turtle|text/ulpfec|text/uri-list|text/vcard|text/vnd.a|text/vnd.abc|text/vnd.ascii-art|text/vnd.curl|text/vnd.curl.dcurl|text/vnd.curl.mcurl|text/vnd.curl.scurl|text/vnd.debian.copyright|text/vnd.dmclientscript|text/vnd.dvb.subtitle|text/vnd.esmertec.theme-descriptor|text/vnd.familysearch.gedcom|text/vnd.ficlab.flt|text/vnd.fly|text/vnd.fmi.flexstor|text/vnd.gml|text/vnd.graphviz|text/vnd.hans|text/vnd.hgl|text/vnd.in3d.3dml|text/vnd.in3d.spot|text/vnd.iptc.newsml|text/vnd.iptc.nitf|text/vnd.latex-z|text/vnd.motorola.reflex|text/vnd.ms-mediapackage|text/vnd.net2phone.commcenter.command|text/vnd.radisys.msml-basic-layout|text/vnd.senx.warpscript|text/vnd.si.uricatalogue|text/vnd.sosi|text/vnd.sun.j2me.app-descriptor|text/vnd.trolltech.linguist|text/vnd.wap.si|text/vnd.wap.sl|text/vnd.wap.wml|text/vnd.wap.wmlscript|text/vtt|text/x-asm|text/x-c|text/x-component|text/x-fortran|text/x-gwt-rpc|text/x-handlebars-template|text/x-java-source|text/x-jquery-tmpl|text/x-lua|text/x-markdown|text/x-nfo|text/x-opml|text/x-org|text/x-pascal|text/x-processing|text/x-sass|text/x-scss|text/x-setext|text/x-sfv|text/x-suse-ymp|text/x-uuencode|text/x-vcalendar|text/x-vcard|text/xml|text/xml-external-parsed-entity|text/yaml|video/1d-interleaved-parityfec|video/3gpp|video/3gpp-tt|video/3gpp2|video/av1|video/bmpeg|video/bt656|video/celb|video/dv|video/encaprtp|video/ffv1|video/flexfec|video/h261|video/h263|video/h263-1998|video/h263-2000|video/h264|video/h264-rcdo|video/h264-svc|video/h265|video/iso.segment|video/jpeg|video/jpeg2000|video/jpm|video/jxsv|video/mj2|video/mp1s|video/mp2p|video/mp2t|video/mp4|video/mp4v-es|video/mpeg|video/mpeg4-generic|video/mpv|video/nv|video/ogg|video/parityfec|video/pointer|video/quicktime|video/raptorfec|video/raw|video/rtp-enc-aescm128|video/rtploopback|video/rtx|video/scip|video/smpte291|video/smpte292m|video/ulpfec|video/vc1|video/vc2|video/vnd.cctv|video/vnd.dece.hd|video/vnd.dece.mobile|video/vnd.dece.mp4|video/vnd.dece.pd|video/vnd.dece.sd|video/vnd.dece.video|video/vnd.directv.mpeg|video/vnd.directv.mpeg-tts|video/vnd.dlna.mpeg-tts|video/vnd.dvb.file|video/vnd.fvt|video/vnd.hns.video|video/vnd.iptvforum.1dparityfec-1010|video/vnd.iptvforum.1dparityfec-2005|video/vnd.iptvforum.2dparityfec-1010|video/vnd.iptvforum.2dparityfec-2005|video/vnd.iptvforum.ttsavc|video/vnd.iptvforum.ttsmpeg2|video/vnd.motorola.video|video/vnd.motorola.videop|video/vnd.mpegurl|video/vnd.ms-playready.media.pyv|video/vnd.nokia.interleaved-multimedia|video/vnd.nokia.mp4vr|video/vnd.nokia.videovoip|video/vnd.objectvideo|video/vnd.radgamettools.bink|video/vnd.radgamettools.smacker|video/vnd.sealed.mpeg1|video/vnd.sealed.mpeg4|video/vnd.sealed.swf|video/vnd.sealedmedia.softseal.mov|video/vnd.uvvu.mp4|video/vnd.vivo|video/vnd.youtube.yt|video/vp8|video/vp9|video/webm|video/x-f4v|video/x-fli|video/x-flv|video/x-m4v|video/x-matroska|video/x-mng|video/x-ms-asf|video/x-ms-vob|video/x-ms-wm|video/x-ms-wmv|video/x-ms-w"
           }
         },
-        "required": [
-          "version",
-          "uri",
-          "mimetype"
-        ]
+        "required": ["version", "uri", "mimetype"]
       },
       "contains": {
         "type": "object",
@@ -176,6 +183,7 @@
     "title",
     "artist",
     "platform",
-    "erc721"
+    "erc721",
+    "uid"
   ]
 }

--- a/src/schema.mjs
+++ b/src/schema.mjs
@@ -301,7 +301,7 @@ export const version = {
 
 // Source: https://eips.ethereum.org/EIPS/eip-721
 export const ERC721Metadata = {
-  type: "object",
+  type: ["object", "null"],
   properties: {
     name: {
       type: "string",
@@ -317,9 +317,9 @@ export const ERC721Metadata = {
   required: ["name", "description", "image"],
 };
 
-export const transaction = {
+export const owner = {
   type: "object",
-  $comment: "History of EIP 721 transfer events",
+  $comment: "Owner of the track",
   properties: {
     from: {
       type: "string",
@@ -337,46 +337,67 @@ export const transaction = {
       type: "string",
       pattern: "0x[a-fA-F0-9]{64}",
     },
+    alias: {
+      type: ["string", "null"],
+      $comment: "Alias for address. For example, ENS.",
+    },
   },
   required: ["from", "to", "blockNumber", "transactionHash"],
+};
+
+export const owners = {
+  type: "array",
+  items: owner,
+};
+
+export const token = {
+  type: "object",
+  properties: {
+    id: {
+      type: "string",
+    },
+    uri: {
+      type: ["string", "null"],
+    },
+    metadata: {
+      ...ERC721Metadata,
+    },
+    owners: {
+      ...owners,
+    },
+  },
+  required: ["id", "owners"],
+};
+
+export const tokens = {
+  type: "array",
+  items: token,
 };
 
 export const ERC721 = {
   type: "object",
   properties: {
     version: { ...version },
-    createdAt: {
-      $comment: "Referring to Ethereum block numbers",
-      type: "integer",
-      minimum: 0,
-    },
-    transaction: {
-      ...transaction,
+    tokens: {
+      ...tokens,
     },
     address: {
+      $comment: "The address where the NFTs are minted",
       type: "string",
       pattern: "0x[a-fA-F0-9]{40}",
     },
-    tokenId: {
-      type: "string",
-    },
-    tokenURI: {
-      type: "string",
-      format: "uri",
+    uri: {
+      $comment:
+        "tokenURI where the metadata was found. Similar to metadata, if tokenURI is common for all tokens we can use this field.",
+      type: ["string", "null"],
     },
     metadata: {
+      $comment:
+        "If the metadata is same for all the tokens we can use this field",
       ...ERC721Metadata,
     },
   },
-  required: [
-    "version",
-    "createdAt",
-    "address",
-    "tokenId",
-    "tokenURI",
-    "metadata",
-    "transaction",
-  ],
+  required: ["version", "tokens", "address"],
 };
 
 export const artist = {
@@ -388,7 +409,6 @@ export const artist = {
     },
     address: {
       type: "string",
-      pattern: "0x[a-fA-F0-9]{40}",
     },
   },
   required: ["version", "name"],
@@ -446,6 +466,10 @@ export const track = {
     title: {
       type: "string",
     },
+    uid: {
+      $comment: "Unique ID to identify the track",
+      type: "string",
+    },
     duration: {
       // Source for ABNF: https://datatracker.ietf.org/doc/html/rfc3339#appendix-A
       type: "string",
@@ -471,6 +495,7 @@ export const track = {
     "artist",
     "platform",
     "erc721",
+    "uid",
   ],
 };
 
@@ -516,7 +541,10 @@ export const all = {
     { $ref: "#/definitions/manifestation" },
     { $ref: "#/definitions/track" },
     { $ref: "#/definitions/crawlPath" },
-    { $ref: "#/definitions/transaction" },
+    { $ref: "#/definitions/owner" },
+    { $ref: "#/definitions/owners" },
+    { $ref: "#/definitions/token" },
+    { $ref: "#/definitions/tokens" },
   ],
   definitions: {
     https,
@@ -535,6 +563,9 @@ export const all = {
     manifestation,
     track,
     crawlPath,
-    transaction,
+    owner,
+    owners,
+    token,
+    tokens,
   },
 };

--- a/test/schema_test.mjs
+++ b/test/schema_test.mjs
@@ -18,7 +18,6 @@ import {
   crawlPath,
   ipfs,
   arweave,
-  transaction,
 } from "../src/schema.mjs";
 
 const ajv = new Ajv();
@@ -65,7 +64,6 @@ test("compile schema", (t) => {
   ajv.compile(manifestations);
   ajv.compile(config);
   ajv.compile(crawlPath);
-  ajv.compile(transaction);
   t.pass();
 });
 
@@ -87,6 +85,7 @@ test("failing to define proper duration format", (t) => {
   const example = {
     version,
     title: "CULTURE",
+    uid: "uid",
     duration: "invalid duration",
     artist: {
       version,
@@ -99,10 +98,7 @@ test("failing to define proper duration format", (t) => {
       uri: "https://sound.xyz",
     },
     erc721: {
-      version,
-      createdAt: 123,
-      address: "0x0000000000000000000000000000000000000000",
-      tokenId: "0",
+      tokens: [],
       metadata: {
         name: "CULTURE",
         description: "song description",
@@ -121,6 +117,7 @@ test("failing to define proper uri format", (t) => {
   const example = {
     version,
     title: "CULTURE",
+    uid: "uid",
     duration: "PT3M",
     artist: {
       version,
@@ -134,9 +131,8 @@ test("failing to define proper uri format", (t) => {
     },
     erc721: {
       version,
-      createdAt: 123,
-      address: "0x0000000000000000000000000000000000000000",
-      tokenId: "0",
+      uri: "false formatting",
+      tokens: [],
       metadata: {
         name: "CULTURE",
         description: "song description",
@@ -153,32 +149,16 @@ test("should fail when no manifestation with audio related mimetype is present",
   const check = ajv.compile(track);
   const version = "0.0.1";
   const example = {
-    version,
-    title: "CULTURE",
-    duration: "PT2M1S",
-    artist: {
-      version,
-      name: "latasha",
-      address: "0x0000000000000000000000000000000000000000",
-    },
-    platform: {
-      version,
-      name: "Sound",
-      uri: "https://www.sound.xyz",
-    },
+    version: "1.0.0",
+    title: "Blast",
+    uid: "polygon/106643/194",
+    duration: "PT05S",
+    artist: { version: "1.0.0", name: "jburn.lens", address: "106643" },
+    platform: { version: "1.0.0", name: "Lens", uri: "https://lens.xyz" },
     erc721: {
-      version,
-      createdAt: 123,
-      address: "0x0000000000000000000000000000000000000000",
-      transaction: {
-        from: "0x0000000000000000000000000000000000000000",
-        to: "0x0000000000000000000000000000000000000000",
-        transactionHash:
-          "0x28b5107ef960dc9c9199f4adf8ff4142b9d53f2cbcab9552b1e492593a3aeadb",
-        blockNumber: 0,
-      },
-      tokenId: "0",
-      tokenURI: "https://example.com/metadata.json",
+      version: "1.0.0",
+      tokens: [],
+      address: "0xe8ebad85fe7eb36ed5b6f12ac95048c7d9bff15b",
       metadata: {
         name: "CULTURE",
         description: "song description",
@@ -198,52 +178,88 @@ test("should fail when no manifestation with audio related mimetype is present",
   t.false(valid);
 });
 
-test("validate value", (t) => {
+test("should be a valid track schema", (t) => {
   const check = ajv.compile(track);
-  const version = "0.0.1";
   const example = {
-    version,
-    title: "CULTURE",
-    duration: "PT2M1S",
-    artist: {
-      version,
-      name: "latasha",
-      address: "0x0000000000000000000000000000000000001234",
-    },
-    platform: {
-      version,
-      name: "Sound",
-      uri: "https://www.sound.xyz",
-    },
+    version: "1.0.0",
+    title: "Blast",
+    uid: "polygon/106643/194",
+    duration: "PT05S",
+    artist: { version: "1.0.0", name: "jburn.lens", address: "106643" },
+    platform: { version: "1.0.0", name: "Lens", uri: "https://lens.xyz" },
     erc721: {
-      version,
-      createdAt: 123,
-      address: "0x0000000000000000000000000000000000000000",
-      transaction: {
-        from: "0x0000000000000000000000000000000000000000",
-        to: "0x0000000000000000000000000000000000000000",
-        transactionHash:
-          "0x28b5107ef960dc9c9199f4adf8ff4142b9d53f2cbcab9552b1e492593a3aeadb",
-        blockNumber: 0,
-      },
-      tokenId: "0",
-      tokenURI: "https://example.com/metadata.json",
+      version: "1.0.0",
+      tokens: [
+        {
+          id: "1",
+          uri: null,
+          metadata: null,
+          owners: [
+            {
+              from: "0x0000000000000000000000000000000000000000",
+              to: "0x77a395A6f7c6E91192697Abb207ea3c171F4B338",
+              blockNumber: 41988367,
+              transactionHash:
+                "0xd622364913527f2d19ac5a09cba872df88a1bc8d37661bccac98ec2d38130787",
+              alias: "n0madz.lens",
+            },
+          ],
+        },
+      ],
+      address: "0xe8ebad85fe7eb36ed5b6f12ac95048c7d9bff15b",
       metadata: {
-        name: "CULTURE",
-        description: "song description",
-        image: "https://example.com/image.jpg",
+        version: "2.0.0",
+        metadata_id: "dfa5863d-b325-47f4-93c7-d8af3d12e48e",
+        content:
+          "1 Wmatic to collect\n" +
+          "25% referral reward\n" +
+          "Nonexclusive Unlimited Usage Rights for owners\n" +
+          "\n" +
+          "Thanks everyone for the support on the beats lately, its been inspirational.",
+        external_url: "https://beatsapp.xyz/profile/jburn.lens",
+        image:
+          "ipfs://bafybeieiuz7xqlrs4aq7gfd3h2ttkt5sjjw43dm57xk3cmpneeiadql4qa",
+        imageMimeType: "image/png",
+        name: "Blast",
+        tags: ["Song", ""],
+        animation_url:
+          "ipfs://bafybeifgvqlonwa3m3rzgdzdix34ob57bap56fmiypsujewm74jruoonli",
+        mainContentFocus: "AUDIO",
+        contentWarning: null,
+        attributes: [
+          { traitType: "type", displayType: "string", value: "audio" },
+          { traitType: "genre", displayType: "string", value: "" },
+          { traitType: "author", displayType: "string", value: "Jburn" },
+        ],
+        media: [
+          {
+            type: "audio/mpeg",
+            altTag: "Audio file",
+            item: "ipfs://bafybeifgvqlonwa3m3rzgdzdix34ob57bap56fmiypsujewm74jruoonli",
+          },
+        ],
+        locale: "en",
+        appId: "beats",
+        description:
+          "1 Wmatic to collect\n" +
+          "25% referral reward\n" +
+          "Nonexclusive Unlimited Usage Rights for owners\n" +
+          "\n" +
+          "Thanks everyone for the support on the beats lately, its been inspirational.",
       },
     },
     manifestations: [
       {
-        version,
-        uri: "https://example.com/audio",
-        mimetype: "audio/mp3",
+        version: "1.0.0",
+        uri: "ipfs://bafybeieiuz7xqlrs4aq7gfd3h2ttkt5sjjw43dm57xk3cmpneeiadql4qa",
+        mimetype: "image",
+        uid: "polygon/106643/194",
       },
       {
-        version,
-        uri: "https://example.com/video",
-        mimetype: "video/mp4",
+        version: "1.0.0",
+        uri: "ipfs://bafybeifgvqlonwa3m3rzgdzdix34ob57bap56fmiypsujewm74jruoonli",
+        mimetype: "audio",
+        uid: "polygon/106643/194",
       },
     ],
   };


### PR DESCRIPTION
This PR changes the schema of the `track`.

The main change is that a track can now include multiple owners. Earlier a track had only one owner and we created multiple tracks with the same data for different owners. As a result, the consumer of neume such as music-os had to combine all the tracks with the same data. This step will no longer be required. Neume will also save space as redundancy is reduced. We couldn't do this change before because of the limitation of LevelDB.

Another change is the addition of the `alias` field for owners to include `*.lens` and `*.eth` names.

This schema also introduces `uid` which is a unique identifier given to each track. `uid` is helpful to structure data in tables in SQL.

**Technical note:** The proposed schema includes `track.erc721.metadata` and `track.erc721.tokens[0].metadata`. The idea is that one of them will be used. If the metadata is the same for all tokens the former can be used otherwise the latter.

<details>
<summary>An example schema representing a song on Lens</summary>

```js
{
  version: "1.0.0",
  title: "Blast",
  uid: "polygon/106643/194",
  duration: "PT05S",
  artist: { version: "1.0.0", name: "jburn.lens", address: "106643" },
  platform: { version: "1.0.0", name: "Lens", uri: "https://lens.xyz" },
  erc721: {
    version: "1.0.0",
    tokens: [
      {
        id: "1",
        uri: null,
        metadata: null,
        owners: [
          {
            from: "0x0000000000000000000000000000000000000000",
            to: "0x77a395A6f7c6E91192697Abb207ea3c171F4B338",
            blockNumber: 41988367,
            transactionHash:
              "0xd622364913527f2d19ac5a09cba872df88a1bc8d37661bccac98ec2d38130787",
            alias: "n0madz.lens",
          },
        ],
      },
    ],
    address: "0xe8ebad85fe7eb36ed5b6f12ac95048c7d9bff15b",
    metadata: {
      version: "2.0.0",
      metadata_id: "dfa5863d-b325-47f4-93c7-d8af3d12e48e",
      content:
        "1 Wmatic to collect\n" +
        "25% referral reward\n" +
        "Nonexclusive Unlimited Usage Rights for owners\n" +
        "\n" +
        "Thanks everyone for the support on the beats lately, its been inspirational.",
      external_url: "https://beatsapp.xyz/profile/jburn.lens",
      image:
        "ipfs://bafybeieiuz7xqlrs4aq7gfd3h2ttkt5sjjw43dm57xk3cmpneeiadql4qa",
      imageMimeType: "image/png",
      name: "Blast",
      tags: ["Song", ""],
      animation_url:
        "ipfs://bafybeifgvqlonwa3m3rzgdzdix34ob57bap56fmiypsujewm74jruoonli",
      mainContentFocus: "AUDIO",
      contentWarning: null,
      attributes: [
        { traitType: "type", displayType: "string", value: "audio" },
        { traitType: "genre", displayType: "string", value: "" },
        { traitType: "author", displayType: "string", value: "Jburn" },
      ],
      media: [
        {
          type: "audio/mpeg",
          altTag: "Audio file",
          item: "ipfs://bafybeifgvqlonwa3m3rzgdzdix34ob57bap56fmiypsujewm74jruoonli",
        },
      ],
      locale: "en",
      appId: "beats",
      description:
        "1 Wmatic to collect\n" +
        "25% referral reward\n" +
        "Nonexclusive Unlimited Usage Rights for owners\n" +
        "\n" +
        "Thanks everyone for the support on the beats lately, its been inspirational.",
    },
  },
  manifestations: [
    {
      version: "1.0.0",
      uri: "ipfs://bafybeieiuz7xqlrs4aq7gfd3h2ttkt5sjjw43dm57xk3cmpneeiadql4qa",
      mimetype: "image",
      uid: "polygon/106643/194",
    },
    {
      version: "1.0.0",
      uri: "ipfs://bafybeifgvqlonwa3m3rzgdzdix34ob57bap56fmiypsujewm74jruoonli",
      mimetype: "audio",
      uid: "polygon/106643/194",
    },
  ],
}
```

> Link to song: https://lenster.xyz/posts/0x01a093-0xc2

</details>

---

### Visual Diagram

![image](https://user-images.githubusercontent.com/4337699/232151166-fe683b19-f473-48bf-98c1-303c61cc9f64.png)

